### PR TITLE
Compatibility with python3

### DIFF
--- a/pelican_dashify/dashify.py
+++ b/pelican_dashify/dashify.py
@@ -31,9 +31,7 @@ def select_stream_by_typed_index(ffprobe_streams, index, codec_type=None):
 
 def run_command(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, *args, **kwargs):
 
-    if six.PY2 and isinstance(command,  unicode):
-        command = shlex.split(command)
-    elif isinstance(command,  str):
+    if isinstance(command,  six.text_type):
         command = shlex.split(command)
 
     process = subprocess.Popen(command, stdout=stdout, stderr=stderr)
@@ -216,12 +214,7 @@ def discover_dashify(generator, content):
 
     for k, v in content.metadata.items():
 
-        if six.PY2:
-            isunicode = isinstance(v, unicode)
-        else:
-            isunicode = isinstance(v, str)
-
-        if isunicode and v.startswith(content.settings["DASHIFY_METATAG"]):
+        if isinstance(v, six.text_type) and v.startswith(content.settings["DASHIFY_METATAG"]):
             input_relpath = v.strip(content.settings["DASHIFY_METATAG"])
 
             try:

--- a/pelican_dashify/dashify.py
+++ b/pelican_dashify/dashify.py
@@ -30,7 +30,7 @@ def select_stream_by_typed_index(ffprobe_streams, index, codec_type=None):
 
 def run_command(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, *args, **kwargs):
 
-    if isinstance(command, unicode):
+    if isinstance(command, str):
         command = shlex.split(command)
 
     process = subprocess.Popen(command, stdout=stdout, stderr=stderr)
@@ -145,7 +145,7 @@ def dashify_video(generator, content, input_relpath, keyword):
     if not os.path.isfile(input_path):
         raise VideoProbeError("The file '{}' does not exist.".format(input_path))
 
-    settings = {k: content.settings[k] for k in DEFAULT_CONFIG.iterkeys()}
+    settings = {k: content.settings[k] for k in DEFAULT_CONFIG.keys()}
     settings.update(load_video_config(input_path))
 
     input_info = load_input_info(input_path, settings)
@@ -157,7 +157,7 @@ def dashify_video(generator, content, input_relpath, keyword):
         raise VideoStreamError("cannot find a valid video stream with index %{}".format(settings["DASHIFY_VIDEO_STREAM_INDEX"]))
 
     sexagesimal_parsed = re.match(settings["DASHIFY_SEXAGESIMAL_REGEX"], input_info["format"]["duration"]).groupdict()
-    output_info["duration"] = datetime.timedelta(**{k: int(v) for k, v in sexagesimal_parsed.iteritems()})
+    output_info["duration"] = datetime.timedelta(**{k: int(v) for k, v in sexagesimal_parsed.items()})
 
     if settings["DASHIFY_EXTRACT_TAGS"]:
         # todo: python native types
@@ -211,9 +211,9 @@ def dashify_video(generator, content, input_relpath, keyword):
 
 def discover_dashify(generator, content):
 
-    for k, v in content.metadata.iteritems():
+    for k, v in content.metadata.items():
 
-        if isinstance(v, unicode) and v.startswith(content.settings["DASHIFY_METATAG"]):
+        if isinstance(v, str) and v.startswith(content.settings["DASHIFY_METATAG"]):
             input_relpath = v.strip(content.settings["DASHIFY_METATAG"])
 
             try:

--- a/pelican_dashify/dashify.py
+++ b/pelican_dashify/dashify.py
@@ -8,6 +8,7 @@ import shlex
 import logging
 import datetime
 import subprocess
+import six
 
 from .settings import DEFAULT_CONFIG, load_video_config
 from .exceptions import VideoProbeError, VideoStreamError, PackingError, AudioTranscodeError, VideoTranscodeError
@@ -30,7 +31,9 @@ def select_stream_by_typed_index(ffprobe_streams, index, codec_type=None):
 
 def run_command(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, *args, **kwargs):
 
-    if isinstance(command, str):
+    if six.PY2 and isinstance(command,  unicode):
+        command = shlex.split(command)
+    elif isinstance(command,  str):
         command = shlex.split(command)
 
     process = subprocess.Popen(command, stdout=stdout, stderr=stderr)
@@ -213,7 +216,12 @@ def discover_dashify(generator, content):
 
     for k, v in content.metadata.items():
 
-        if isinstance(v, str) and v.startswith(content.settings["DASHIFY_METATAG"]):
+        if six.PY2:
+            isunicode = isinstance(v, unicode)
+        else:
+            isunicode = isinstance(v, str)
+
+        if isunicode and v.startswith(content.settings["DASHIFY_METATAG"]):
             input_relpath = v.strip(content.settings["DASHIFY_METATAG"])
 
             try:

--- a/pelican_dashify/settings.py
+++ b/pelican_dashify/settings.py
@@ -56,5 +56,5 @@ def load_video_config(path):
 
 def register_settings(pelican):
 
-    for k, v in DEFAULT_CONFIG.iteritems():
+    for k, v in DEFAULT_CONFIG.items():
         pelican.settings.setdefault(k, v)


### PR DESCRIPTION
This PR addresses the issue #2 and complies to what is described in [pelican's documentation](https://docs.getpelican.com/en/stable/contribute.html?highlight=contribution#python-2-3-compatibility-development-tips).

That is:

- `dict->iteritems` and `dict->iterkeys` are converted to `dict->items` and `dict->keys` respectivley.
- `six.text_type` instead of `unicode` (for Python 2) / `str` (for Python 3)
